### PR TITLE
Add an AudioConfig

### DIFF
--- a/AcceptableValueListSorted.cs
+++ b/AcceptableValueListSorted.cs
@@ -1,0 +1,65 @@
+﻿using BepInEx.Configuration;
+using System;
+
+namespace LCMaxSoundFix
+{
+    public class AcceptableValueListSorted<T> : AcceptableValueList<T> where T : IEquatable<T>, IComparable<T>
+    {
+        public AcceptableValueListSorted(params T[] acceptableValues)
+            : base(acceptableValues)
+        {
+            Array.Sort(AcceptableValues);
+        }
+
+        public override object Clamp(object value)
+        {
+            if (value is IComparable<T>)
+            {
+                int closestIndex = 0;
+                T comparableValue = (T)value;
+                for (int i = 0; i < AcceptableValues.Length; ++i)
+                {
+                    int comp = AcceptableValues[i].CompareTo(comparableValue);
+                    if (comp == 0)
+                    {
+                        // We found a perfect match!
+                        closestIndex = i;
+                        break;
+                    }
+                    else if (comp < 0)
+                    {
+                        closestIndex = i;
+                    }
+                    else if (comp > 0)
+                    {
+                        if (i == 0)
+                        {
+                            // We are at the start of the array, so we cannot compare to the previous value.
+                            closestIndex = i;
+                            break;
+                        }
+
+                        // The dynamic keyword isn't supported by IL2CPP, so check the type manually...
+                        if (typeof(T) == typeof(int))
+                        {
+                            int currDiff = Math.Abs(Convert.ToInt32(AcceptableValues[i]) - (int)value);
+                            int prevDiff = Math.Abs(Convert.ToInt32(AcceptableValues[i - 1]) - (int)value);
+
+                            // Returns the closest value in the list.
+                            closestIndex = currDiff < prevDiff ? i : i - 1;
+                            break;
+                        }
+
+                        // By default, return the previous value.
+                        break;
+                    }
+                }
+
+                return AcceptableValues[closestIndex];
+            }
+
+            // Returns the matching value or the first value by default.
+            return base.Clamp(value);
+        }
+    }
+}

--- a/AudioConfig.cs
+++ b/AudioConfig.cs
@@ -1,0 +1,68 @@
+﻿using BepInEx.Configuration;
+using BepInEx;
+using System;
+using UnityEngine;
+
+namespace LCMaxSoundFix
+{
+    internal static class AudioConfig
+    {
+        private static ConfigEntry<int> _numRealVoices = null;
+        private static ConfigEntry<int> _numVirtualVoices = null;
+
+        private static readonly int[] _validNumVoices =
+        {
+            1, 2, 4, 8, 16, 32, 50, 64, 100, 128, 256, 512, 1024
+        };
+
+        public static void Bind(BaseUnityPlugin plugin)
+        {
+            if (plugin is null)
+            {
+                throw new ArgumentNullException(nameof(plugin));
+            }
+
+            Unbind();
+
+            _numRealVoices = plugin.Config.Bind("Audio Settings", "Real Voices", 128, new ConfigDescription("The current maximum number of simultaneously audible sounds in the game. Game default: 40", new AcceptableValueListSorted<int>(_validNumVoices)));
+            _numVirtualVoices = plugin.Config.Bind("Audio Settings", "Virtual Voices", 1024, new ConfigDescription("The maximum number of managed sounds in the game. Beyond this limit sounds will simply stop playing. Game default: 512", new AcceptableValueListSorted<int>(_validNumVoices)));
+
+            _numRealVoices.SettingChanged += OnSettingChanged;
+            _numVirtualVoices.SettingChanged += OnSettingChanged;
+
+            ApplyChanges();
+        }
+
+        public static void Unbind()
+        {
+            if (_numRealVoices != null)
+            {
+                _numRealVoices.SettingChanged -= OnSettingChanged;
+                _numRealVoices.ConfigFile.Remove(_numRealVoices.Definition);
+                _numRealVoices = null;
+            }
+
+            if (_numVirtualVoices != null)
+            {
+                _numVirtualVoices.SettingChanged -= OnSettingChanged;
+                _numVirtualVoices.ConfigFile.Remove(_numVirtualVoices.Definition);
+                _numVirtualVoices = null;
+            }
+        }
+
+        private static void OnSettingChanged(object sender, EventArgs e)
+        {
+            ApplyChanges();
+        }
+
+        private static void ApplyChanges()
+        {
+            Plugin.Logger?.LogDebug("Applying audio settings...");
+            AudioConfiguration audioConfig = AudioSettings.GetConfiguration();
+            audioConfig.numRealVoices = _numRealVoices.Value;
+            audioConfig.numVirtualVoices = _numVirtualVoices.Value;
+            AudioSettings.Reset(audioConfig);
+            Plugin.Logger?.LogInfo($"Audio settings (numRealVoices={_numRealVoices.Value}; numVirtualVoices={_numVirtualVoices.Value}) are applied.");
+        }
+    }
+}

--- a/LCMaxSoundFix.csproj
+++ b/LCMaxSoundFix.csproj
@@ -3,8 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.1</TargetFramework>
     <AssemblyName>LCMaxSoundsFix</AssemblyName>
-    <Description>My first plugin</Description>
-    <Version>1.1.0</Version>
+    <Description>Simple mod that increase max number of simultaneous playing sounds, hopefully fixing missing footsteps and other missing sound problems.</Description>
+    <Version>1.2.0</Version>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>

--- a/Plugin.cs
+++ b/Plugin.cs
@@ -1,24 +1,24 @@
 ﻿using BepInEx;
-using UnityEngine;
+using BepInEx.Logging;
 
 namespace LCMaxSoundFix
 {
     [BepInPlugin("." + PluginInfo.PLUGIN_GUID, PluginInfo.PLUGIN_NAME, PluginInfo.PLUGIN_VERSION)]
-    public class Plugin : BaseUnityPlugin
+    internal class Plugin : BaseUnityPlugin
     {
-        private void Awake()
+        internal static new ManualLogSource Logger { get; private set; } = null;
+
+        protected Plugin() : base()
         {
-            // Plugin startup logic
+            Logger = base.Logger;
+        }
 
-            var audioSettings = AudioSettings.GetConfiguration();
-            // default - 40
-            audioSettings.numRealVoices = 128;
-            // default - 512
-            audioSettings.numVirtualVoices = 1024;
-            AudioSettings.Reset(audioSettings);
+        protected void Awake()
+        {
+            Logger?.LogInfo($"Plugin {PluginInfo.PLUGIN_NAME} is loaded!");
 
-            Logger.LogInfo($"Plugin LCMaxSoundsFix is loaded, new audio settings are applied.");
-
+            Logger?.LogDebug("Binding audio config...");
+            AudioConfig.Bind(this);
         }
     }
 }


### PR DESCRIPTION
The AudioConfig allows to edit real/virtual voices, even at runtime (tested with LethalConfig), which is useful to tweak it in game or reduce these numbers when the audio becomes overwhelming or performances can't keep up.
The config take a list of acceptable values which comes from Unity documentation and takes the closest value if the one entered isn't valid (instead of the first value by default).
I also updated the project description and version.

Here's how it looks in game with LethalConfig:
![image](https://github.com/Hardeh/LCMaxSoundFix/assets/14890613/61302ea0-d07c-495c-a45f-1d23285382a2)